### PR TITLE
Merged error handling and UI updates from 'error' branch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,21 +61,19 @@ class _MyHomePageState extends State<MyHomePage> {
             stream: _firestoreService.getNumber(),
             builder: (BuildContext context,
                 AsyncSnapshot<DocumentSnapshot> snapshot) {
+              int currentNumber = 0; // Default value
+
               if (snapshot.hasError) {
-                return const Text('Something went wrong');
+                print('Something went wrong');
+              } else if (snapshot.connectionState == ConnectionState.waiting) {
+                print("Loading");
+              } else {
+                Map<String, dynamic> data =
+                    snapshot.data!.data() as Map<String, dynamic>;
+                currentNumber = data['currentNumber'];
               }
 
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Text("Loading");
-              }
-
-              if (!snapshot.hasData || !snapshot.data!.exists) {
-                return Text('Document does not exist');
-              }
-
-              Map<String, dynamic> data =
-                  snapshot.data!.data() as Map<String, dynamic>;
-              return Text("Data: ${data['currentNumber']}");
+              return Text("Current number: $currentNumber");
             },
           ),
           ElevatedButton(
@@ -114,6 +112,12 @@ class _MyHomePageState extends State<MyHomePage> {
               }
             },
           ),
+          ElevatedButton(
+            onPressed: () async {
+              await _firestoreService.signOut();
+            },
+            child: Text('Log Out'),
+          ),
         ],
       ),
       floatingActionButton: FloatingActionButton(
@@ -129,7 +133,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void dispose() {
     _emailController.dispose();
-       _passwordController.dispose();
+    _passwordController.dispose();
     super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'St James Park',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
@@ -79,6 +79,24 @@ class _MyHomePageState extends State<MyHomePage> {
             },
           ),
           ElevatedButton(
+            child: const Text('Sign Up'),
+            onPressed: () async {
+              try {
+                await _auth.createUserWithEmailAndPassword(
+                  email: _emailController.text,
+                  password: _passwordController.text,
+                );
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Successfully Signed Up')),
+                );
+              } on FirebaseAuthException catch (e) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Failed with ${e.message}')),
+                );
+              }
+            },
+          ),
+          ElevatedButton(
             child: const Text('Log In'),
             onPressed: () async {
               try {
@@ -86,9 +104,13 @@ class _MyHomePageState extends State<MyHomePage> {
                   email: _emailController.text,
                   password: _passwordController.text,
                 );
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Successfully Logged In')),
+                );
               } on FirebaseAuthException catch (e) {
-                // Handle error
-                print(e.message);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Failed with ${e.message}')),
+                );
               }
             },
           ),
@@ -107,7 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void dispose() {
     _emailController.dispose();
-    _passwordController.dispose();
+       _passwordController.dispose();
     super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,19 +61,24 @@ class _MyHomePageState extends State<MyHomePage> {
             stream: _firestoreService.getNumber(),
             builder: (BuildContext context,
                 AsyncSnapshot<DocumentSnapshot> snapshot) {
-              int currentNumber = 0; // Default value
-
               if (snapshot.hasError) {
-                print('Something went wrong');
-              } else if (snapshot.connectionState == ConnectionState.waiting) {
-                print("Loading");
-              } else {
-                Map<String, dynamic> data =
-                    snapshot.data!.data() as Map<String, dynamic>;
-                currentNumber = data['currentNumber'];
+                return const Text('Something went wrong');
               }
 
-              return Text("Current number: $currentNumber");
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Text("Loading");
+              }
+              if (snapshot.connectionState == ConnectionState.active) {
+                if (snapshot.data!.exists) {
+                  Map<String, dynamic> data =
+                      snapshot.data!.data() as Map<String, dynamic>;
+                  return Text("Data: ${data['currentNumber']}");
+                } else {
+                  return Text('Document does not exist');
+                }
+              }
+
+              return const Text('Unknown state');
             },
           ),
           ElevatedButton(

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,22 +1,26 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class FirestoreService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
 
   Stream<DocumentSnapshot> getNumber() {
     return _firestore.collection('numbers').doc('currentNumber').snapshots();
   }
 
-  Future<void> incrementNumber() async {
-    DocumentReference numberRef =
-        _firestore.collection('numbers').doc('currentNumber');
-    DocumentSnapshot numberSnap = await numberRef.get();
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
 
-    if (numberSnap.exists) {
-      int currentNumber = (numberSnap.data() as dynamic)['number'];
-      await numberRef.update({'number': currentNumber + 1});
-    } else {
-      await numberRef.set({'number': 1});
+  Future<void> incrementNumber() async {
+    try {
+      await _firestore.collection('numbers').doc('currentNumber').update({
+        'currentNumber': FieldValue.increment(1),
+      });
+      print('Number incremented successfully');
+    } catch (e) {
+      print('Failed to increment number: $e');
     }
   }
 }


### PR DESCRIPTION
Before the changes:
![image](https://github.com/joelc0193/st_james_park_app/assets/20515566/81a7810a-923b-46cf-8d80-fd9b0b1bcc05)

In the initial state, when the user clicked the increment button, the app would attempt to increment the number in Firestore. If there was an error (for example, the user was not authenticated), the app would display an error message.

After the changes:
![image](https://github.com/joelc0193/st_james_park_app/assets/20515566/c825c7b1-81cb-4f35-9cbc-bdbddc3555fa)

Now, when the user clicks the increment button, theapp still attempts to increment the number in Firestore. However, if there's an error, the app will display the current number instead of an error message. This way, the user can still see the current number even if they're not authenticated.

